### PR TITLE
Pre-load tiles

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,11 @@
         {% endblock %}
         <link rel="icon" type="image/png" sizes="96x96" href="{{ url_for('static', filename='img/favicon.png') }}">
         {% endblock %}
+        <link rel="preload" href="{{ url_for('static', filename='img/tiles/ST_0.png') }}" as="image">
+        {% for tile_num in range(18,50) %}
+            <link rel="preload" href="{{ url_for('static', filename='img/tiles/ST_' + tile_num|string + '.png') }}" as="image">
+        {% endfor %}
+
     </head>
     <body class="d-flex flex-column h-100">
         <header>


### PR DESCRIPTION
Added a series of preload links to the header, which automatically load in all relevant tiles. In the future, if home worlds are assigned, just expand the range to be the entire list of hexes. For now we are only using 0 and 18 through 50.

Closes #5