### PR TITLE
8 Settlers Of Catan Like Picks

### DIFF
--- a/helpers/board_data.py
+++ b/helpers/board_data.py
@@ -53,9 +53,9 @@ boards = {
                            'victory points.',
             'empty_tiles': [11, 17, 19, 20, 24, 25, 26, 27, 28, 29, 33, 34, 35, 36],
             'home_worlds': [22, 31],
-            'primary_tiles': [32, 15, 30, 21, 9, 23],
-            'secondary_tiles': [16, 5, 14, 8, 2, 10],
-            'tertiary_tiles': [4, 13, 3, 12, 1, 7, 6, 18]
+            'primary_tiles': [9, 15, 21, 30, 23, 32],
+            'secondary_tiles': [5, 2, 16, 10, 14, 8],
+            'tertiary_tiles': [7, 13, 18, 12, 1, 4, 3, 6]
         }
     },
     3: {
@@ -64,17 +64,17 @@ boards = {
                            'victory points.',
             'empty_tiles': [19, 20, 24, 25, 26, 30, 31, 32, 36],
             'home_worlds': [22, 28, 34],
-            'primary_tiles': [9, 13, 17, 21, 23, 27, 29, 33, 35],
-            'secondary_tiles': [7, 8, 10, 11, 12, 14, 15, 16, 18],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6]
+            'primary_tiles': [9, 13, 17, 33, 27, 21, 23, 29, 35],
+            'secondary_tiles': [16, 12, 8, 10, 14, 18, 15, 11, 7],
+            'tertiary_tiles': [2, 4, 6, 5, 3, 1]
         },
         'compact': {
             'description': 'A more compact variant, that encourages fighting. Recommended to play '
                            'with high resource values.',
             'empty_tiles': [19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36],
             'home_worlds': [10, 14, 18],
-            'primary_tiles': [7, 9, 11, 13, 15, 17],
-            'secondary_tiles': [1, 2, 3, 4, 5, 6],
+            'primary_tiles': [7, 11, 15, 13, 9, 17],
+            'secondary_tiles': [1, 3, 5, 4, 2, 6],
             'tertiary_tiles': [8, 12, 16]
         },
         'manta': {
@@ -82,8 +82,8 @@ boards = {
             'empty_tiles': [7, 8, 9, 17, 18, 19, 20, 21, 22, 23, 33, 34, 35, 36],
             'home_worlds': [25, 28, 31],
             'primary_tiles': [11, 13, 15],
-            'secondary_tiles': [24, 26, 27, 29, 30, 32],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6, 10, 12, 14, 16]
+            'secondary_tiles': [32, 29, 24, 26, 27, 30],
+            'tertiary_tiles': [5, 4, 3, 12, 14, 10, 16, 6, 2, 1]
         }
     },
     4: {
@@ -92,9 +92,9 @@ boards = {
                            'victory points.',
             'empty_tiles': [],
             'home_worlds': [23, 27, 32, 36],
-            'primary_tiles': [19, 22, 24, 26, 28, 31, 33, 35],
-            'secondary_tiles': [7, 9, 10, 12, 13, 15, 16, 18],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6, 8, 11, 14, 17, 20, 21, 25, 29, 30, 34]
+            'primary_tiles': [19, 24, 28, 31, 33, 26, 22, 35],
+            'secondary_tiles': [13, 16, 7, 10, 9, 18, 15, 12],
+            'tertiary_tiles': [1, 3, 5, 4, 2, 6, 14, 17, 8, 11, 25, 21, 34, 29, 30, 20]
         },
         'horizontal': {
             'description': 'A slightly smaller than normal 4 player board which is aligned '
@@ -102,24 +102,24 @@ boards = {
             'empty_tiles': [19, 20, 27, 28, 29, 36],
             'home_worlds': [22, 25, 31, 34],
             'primary_tiles': [9, 11, 15, 17],
-            'secondary_tiles': [21, 23, 24, 26, 30, 32, 33, 35],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 13, 14, 16, 18, 22, 25, 31, 34]
+            'secondary_tiles': [35, 30, 26, 21, 23, 24, 32, 33],
+            'tertiary_tiles': [3, 5, 6, 2, 1, 4, 14, 18, 8, 12, 10, 7, 16, 13]
         },
         'vertical': {
             'description': 'An even smaller board aligned vertically.',
             'empty_tiles': [19, 22, 23, 24, 25, 31, 32, 33, 34],
             'home_worlds': [21, 26, 30, 35],
-            'primary_tiles': [9, 11, 15, 17, 20, 27, 29, 36],
-            'secondary_tiles': [7, 8, 12, 13, 14, 18],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6, 10, 16]
+            'primary_tiles': [9, 11, 15, 17, 36, 29, 27, 20],
+            'secondary_tiles': [14, 18, 8, 12, 13, 7],
+            'tertiary_tiles': [1, 4, 6, 5, 3, 2, 10, 16]
         },
         'gaps': {
             'description': 'Vertical, but with gaps to encourage fights with neighbors.',
             'empty_tiles': [1, 4, 19, 22, 23, 24, 25, 31, 32, 33, 34],
             'home_worlds': [21, 26, 30, 35],
-            'primary_tiles': [9, 11, 15, 17, 20, 27, 29, 36],
-            'secondary_tiles': [7, 8, 12, 13, 14, 18],
-            'tertiary_tiles': [2, 3, 5, 6, 10, 16]
+            'primary_tiles': [9, 11, 15, 17, 36, 29, 27, 20],
+            'secondary_tiles': [14, 18, 8, 12, 13, 7],
+            'tertiary_tiles': [6, 5, 3, 2, 10, 16]
         }
     },
     5: {
@@ -128,9 +128,9 @@ boards = {
                            'victory points.',
             'empty_tiles': [],
             'home_worlds': [21, 25, 28, 31, 35],
-            'primary_tiles': [9, 11, 13, 15, 17],
-            'secondary_tiles': [8, 18, 22, 24, 26, 27, 29, 30, 32, 34],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6, 7, 10, 12, 14, 16, 19, 20, 23, 33, 36]
+            'primary_tiles': [13, 15, 11, 17, 9],
+            'secondary_tiles': [27, 24, 30, 34, 22, 8, 18, 32, 26, 29],
+            'tertiary_tiles': [4, 3, 5, 2, 6, 1, 10, 12, 14, 16, 33, 23, 7, 19, 20, 36]
         },
         'diamond': {
             'description': 'A slightly smaller map than normal, which focuses on being closer to '
@@ -138,8 +138,8 @@ boards = {
             'empty_tiles': [22, 25, 26, 30, 31, 34],
             'home_worlds': [21, 24, 28, 32, 35],
             'primary_tiles': [9, 11, 13, 15, 17],
-            'secondary_tiles': [8, 10, 16, 18, 20, 23, 27, 29, 33, 36],
-            'tertiary_tiles': [1, 2, 3, 4, 5, 6, 7, 12, 14, 19]
+            'secondary_tiles': [18, 16, 29, 10, 8, 20, 23, 27, 33, 36],
+            'tertiary_tiles': [6, 4, 2, 1, 3, 5, 7, 12, 14, 19]
         },
     },
     6: {
@@ -149,17 +149,17 @@ boards = {
             'empty_tiles': [],
             'home_worlds': [19, 22, 25, 28, 31, 34],
             'primary_tiles': [7, 9, 11, 13, 15, 17],
-            'secondary_tiles': [20, 21, 23, 24, 26, 27, 29, 30, 32, 33, 35, 36],
-            'tertiary_tiles': [8, 10, 12, 14, 16, 18, 1, 2, 3, 4, 5, 6]
+            'secondary_tiles': [33, 30, 27, 24, 21, 36, 20, 23, 26, 29, 32, 35],
+            'tertiary_tiles': [18, 16, 14, 12, 10, 8, 4, 6, 2, 3, 5, 1]
         },
         'warzone': {
             'description': 'To battle stations! This map layout favors the center of the galaxy. '
                            'Focus on controlling planets around Mecatol Rex.',
             'empty_tiles': [],
             'home_worlds': [19, 22, 25, 28, 31, 34],
-            'primary_tiles': [8, 10, 12, 14, 16, 18, 1, 2, 3, 4, 5, 6],
-            'secondary_tiles': [7, 9, 11, 13, 15, 17],
-            'tertiary_tiles': [20, 21, 23, 24, 26, 27, 29, 30, 32, 33, 35, 36]
+            'primary_tiles': [8, 4, 6, 2, 3, 5, 1, 18, 16, 14, 12, 10],
+            'secondary_tiles': [33, 30, 27, 24, 21, 36, 20, 23, 26, 29, 32, 35],
+            'tertiary_tiles': [7, 9, 11, 13, 15, 17]
         }
     }
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -141,6 +141,20 @@ body {
     top: 0;
     left: 0;
 }
+.overlay {
+    position: absolute;
+    text-align: center;
+    z-index: 2; /* Raise above images */
+    text-shadow:2px 2px 0 #000,
+    -2px -2px 0 #000,
+    2px -2px 0 #000,
+    -2px 2px 0 #000,
+    0px 2px 0 #000,
+    2px 0px 0 #000,
+    0px -2px 0 #000,
+    -2px 0px 0 #000,
+    2px 2px 5px #000;
+}
 .center-map {
     top: 50%;
     left: 50%;

--- a/static/js/createMap.js
+++ b/static/js/createMap.js
@@ -101,6 +101,7 @@ function drawMap() {
     // Loop over tiles to assign various values to them
     for (let tileNumber = 0; tileNumber < offsets.length; tileNumber++) {
         let tile = $("#tile-" + tileNumber);
+        let numOverlay = $("#num-" + tileNumber);
         tile.attr("src", "/static/img/tiles/ST_" + currentTiles[tileNumber] + ".png")
             .attr("width", constraintWidth)
             .attr("height", constraintHeight)
@@ -109,6 +110,22 @@ function drawMap() {
             .css("left", (mapNumberTilesWidth / 2) * constraintWidth)
             .css("top", (mapNumberTilesHeight / 2) * constraintHeight)
             .css("display", "block")
+
+        numOverlay.css("width", constraintWidth)
+            .css("height", constraintHeight)
+            .css("line-height", constraintHeight + "px")
+            .css("margin-left", offsets[tileNumber][0])
+            .css("margin-top", offsets[tileNumber][1])
+            .css("left", (mapNumberTilesWidth / 2) * constraintWidth)
+            .css("top", (mapNumberTilesHeight / 2) * constraintHeight)
+            .css("display", "block").html(currentTiles[tileNumber])
+
+
+        if (currentTiles[tileNumber] === 0 || currentTiles[tileNumber] === -1) {
+            numOverlay.hide()
+        } else {
+            numOverlay.show()
+        }
     }
 
     // Clear any css classes on the map

--- a/templates/index.html
+++ b/templates/index.html
@@ -153,7 +153,7 @@
 
         {% block scripts %}
             <script>
-                var currentTiles = {{ tiles|tojson }};
+                var currentTiles = {{ tiles }};
                 var zoom = 1.0;
                 const BOARD_STYLES = {{ all_board_styles|tojson }};
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -10,12 +10,11 @@
 <div id="tiMap" class="map">
     {% for index in range(37) %}
         <div class="tile-wrapper">
+            <span id="num-{{ index }}" class="overlay">{{ index }}</span>
             <img id="tile-{{ index }}"
                  class="tile"
-                    {# style="margin-left: {{ offsets_136[index][0] }}px; margin-top: {{ offsets_136[index][1] }}px;"#}
                  src=""
                  draggable="true" ondragstart="drag(event)" ondrop="drop(event)" ondragover="allowDrop(event)"
-                    {# width="136" height="119"#}
                  alt=""
                  onerror="this.style.display='none'"
             />

--- a/ti4_web.py
+++ b/ti4_web.py
@@ -4,7 +4,6 @@ The main starting file for this flask project, which is in charge of creating th
 starting it based off of configuration and environment variables.
 """
 import os
-import random
 
 from logging.config import dictConfig
 from flask import Flask, render_template, jsonify, request, json
@@ -57,20 +56,8 @@ def create_application():
         """
         log.debug('Running the main page. Application is running as a %s server.', env)
 
-        tiles_as_str: str = request.args.get('tiles', '[]')
-        # Attempt to convert tiles
-        if tiles_as_str[0] == '[':
-            tiles_as_str = tiles_as_str[1:]
-        if tiles_as_str[len(tiles_as_str) - 1] == ']':
-            tiles_as_str = tiles_as_str[:-1]
-        tiles_as_str = tiles_as_str.replace(' ', '')
-        tiles: list = tiles_as_str.split(',')
+        tiles: str = request.args.get('tiles', '[]')
 
-        # Change default back to empty list
-        if tiles == ['']:
-            tiles = []
-
-        # Initial values for the first load of the page
         ti_board = TI4Board(6)
         form_info = {
             'player_count': [6, 5, 4, 3, 2],


### PR DESCRIPTION
Modified board so non randomized picks are in a specific order. This order is to prevent one player getting all the first picks. For example, if there are 3 people in the game, pick order is: 1, 2, 3, 3, 2, 1... and so on.

Also includes overlay text which sits on top of tile images and displays what tile number it is.

Closes #8 