### PR TITLE
fix(map) fix for Nekro and Naalu homesystems not visible after genera…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -574,7 +574,7 @@ class App extends React.Component {
                     return result[1];
                 }
             } else {
-                let regex = /^([0-7][0-9]?|80|81|82|-1)-?([0-5])?$/gm
+                let regex = /^(80|81|82|-1|[0-7]?[0-9])-?([0-5])?$/gm
                 result = regex.exec(tile);
                 if (result) {
                     return Number(result[1])


### PR DESCRIPTION
Found out the bug that caused Nekro and Naalu homesystems being displayed as -1 tile after generation. It was due to regex not matching 8 and 9.