### PR TITLE
Fixed 5 player maps having the wrong red/blue ratio when playing with hyperlanes

### DIFF
--- a/src/data/boardData.json
+++ b/src/data/boardData.json
@@ -134,7 +134,8 @@
                 "primary_tiles": [7, 9, 11, 15, 17],
                 "secondary_tiles": [6, 5, 3, 2, 1, 13, 16, 18, 8, 10],
                 "tertiary_tiles": [20, 23, 26, 32, 35, 33, 30, 24, 21, 36],
-                "hyperlane_tiles": [[4, "86A", 0], [12, "88A", 0], [14, "87A", 0], [27, "83A", 0], [28, "85A", 0], [29, "84A", 0]]
+                "hyperlane_tiles": [[4, "86A", 0], [12, "88A", 0], [14, "87A", 0], [27, "83A", 0], [28, "85A", 0], [29, "84A", 0]],
+                "overrideRatios": { "blueTileRatio": 3, "redTileRatio": 2 }
             },
             "diamond": {
                 "description": "A slightly smaller map than normal, which focuses on being closer to Mecatol Rex.",

--- a/src/options/MapOptions.js
+++ b/src/options/MapOptions.js
@@ -588,23 +588,32 @@ class MapOptions extends React.Component {
         // Calculate how many reds we need based on player count
         let blueTileRatio = 2;
         let redTileRatio = 1;
-        // For 3, 4, and 6 player games, there is a different ratio
-        switch (this.state.currentNumberOfPlayers) {
-            case(3):
-                blueTileRatio = 3
-                redTileRatio = 1
-                break;
-            case(4):
-                blueTileRatio = 5
-                redTileRatio = 3
-                break;
-            case(6):
-                blueTileRatio = 3
-                redTileRatio = 2
-                break;
-            default:
-                break;
+
+        //If the board style overrides blue and red ratios we use those values, otherwise we go to the switch statement
+        const currentBoardStyle = boardData.styles[this.state.currentNumberOfPlayers][this.state.currentBoardStyle];
+        if(currentBoardStyle['overrideRatios'] !== undefined) {
+            blueTileRatio = currentBoardStyle['overrideRatios']['blueTileRatio'];
+            redTileRatio = currentBoardStyle['overrideRatios']['redTileRatio'];
+        } else {
+            // For 3, 4, and 6 player games, there is a different ratio
+            switch (this.state.currentNumberOfPlayers) {
+                case(3):
+                    blueTileRatio = 3
+                    redTileRatio = 1
+                    break;
+                case(4):
+                    blueTileRatio = 5
+                    redTileRatio = 3
+                    break;
+                case(6):
+                    blueTileRatio = 3
+                    redTileRatio = 2
+                    break;
+                default:
+                    break;
+            }
         }
+
         let redsToPlace = Math.round(Number((numberOfSystems / (blueTileRatio + redTileRatio)) * redTileRatio));
         let bluesToPlace = Math.round(Number((numberOfSystems / (blueTileRatio + redTileRatio)) * blueTileRatio));
 


### PR DESCRIPTION
I added a new optional property to board styles which will allow them to override the red/blue ratios.

Closes #87 