### PR TITLE
Fixed an issue where red tiles would sometimes erroneously be replaced with planet wormholes

### DIFF
--- a/src/options/MapOptions.js
+++ b/src/options/MapOptions.js
@@ -1001,7 +1001,7 @@ class MapOptions extends React.Component {
     }
 
     ensureWormholesForType(possibleTiles, planetWormholes, allWormholes, oppositeWormholes, useProphecyOfKings) {
-        let allAnomalyList = useProphecyOfKings ? [...tileData.anomaly.concat(tileData.pokAnomaly)] : [...tileData.anomaly];
+        let allAnomalyList = useProphecyOfKings ? [...tileData.red.concat(tileData.pokRed)] : [...tileData.red];
         let unusedWormholes = [];
         let usedWormholes = [];
 


### PR DESCRIPTION
When we try to replace a wormhole we filter out only the anomalies, when we should be filtering all the red tiles. This means that we sometimes end up replacing a red non-anomaly tile with a blue planet tile. This throws off the ratio between blue and red tiles.