### PR TITLE
Added the option to ensure the generation of anomalies with racial benefits

### DIFF
--- a/src/data/tileData.json
+++ b/src/data/tileData.json
@@ -13,6 +13,14 @@
     "pokAlphaWormholes": [79],
     "betaWormholes": [25, 40],
     "pokBetaWormholes": [64],
+    "asteroidFields": [44, 45],
+    "pokAsteroidFields": [79],
+    "gravityRifts": [41],
+    "pokGravityRifts": [67],
+    "nebulae": [42],
+    "pokNebulae": [68],
+    "supernovas": [43],
+    "pokSupernovas": [80],
     "hyperlanes": ["83A", "83B", "84A", "84B", "85A", "85B", "86A", "86B", "87A", "87B", "88A", "88B", "89A", "89B", "90A", "90B", "91A", "91B"],
     "all": {
         "1": {

--- a/src/options/MapOptions.js
+++ b/src/options/MapOptions.js
@@ -738,7 +738,8 @@ class MapOptions extends React.Component {
                     "planet_count": parseInt(this.state.planetCountWeight),
                     "specialty": parseInt(this.state.specialtyWeight),
                     "anomaly": parseInt(this.state.anomalyWeight),
-                    "wormhole": parseInt(this.state.wormholeWeight)
+                    "wormhole": parseInt(this.state.wormholeWeight),
+                    "racial": parseInt(this.state.wormholeWeight) - 5
                 }
                 break;
             case "resource":
@@ -748,7 +749,8 @@ class MapOptions extends React.Component {
                     "planet_count": 10,
                     "specialty": 10,
                     "anomaly": 10,
-                    "wormhole": 10
+                    "wormhole": 10,
+                    "racial": 5
                 }
                 break;
             case "influence":
@@ -758,7 +760,8 @@ class MapOptions extends React.Component {
                     "planet_count": 10,
                     "specialty": 10,
                     "anomaly": 10,
-                    "wormhole": 10
+                    "wormhole": 10,
+                    "racial": 5
                 }
                 break;
             case "balanced":
@@ -770,7 +773,8 @@ class MapOptions extends React.Component {
                         "planet_count": 15,
                         "specialty": 50,
                         "anomaly": 40,
-                        "wormhole": 25
+                        "wormhole": 25,
+                        "racial": 20
                     }
                 } else {
                     weights = {
@@ -779,14 +783,15 @@ class MapOptions extends React.Component {
                         "planet_count": 15,
                         "specialty": 40,
                         "anomaly": 30,
-                        "wormhole": 25
+                        "wormhole": 25,
+                        "racial": 20
                     }
                 }
                 break;
         }
 
         // Re-order the planets based on their weights
-        newSystems = this.getWeightedPlanetList(newSystems, weights)
+        newSystems = this.getWeightedPlanetList(newSystems, weights, ensuredAnomalies)
 
         return newSystems
 
@@ -1177,11 +1182,11 @@ class MapOptions extends React.Component {
     }
 
     // TODO rename from planet to tile
-    getWeightedPlanetList(possiblePlanets, weights) {
+    getWeightedPlanetList(possiblePlanets, weights, ensuredAnomalies) {
         // Generate an array of tuples where the first element is the plant's tile number and the second is its weight
         let planetWeights = [];
         for (let planetTileNumber in possiblePlanets) {
-            planetWeights.push([possiblePlanets[planetTileNumber], this.getWeight(possiblePlanets[planetTileNumber], weights)])
+            planetWeights.push([possiblePlanets[planetTileNumber], this.getWeight(possiblePlanets[planetTileNumber], weights, ensuredAnomalies)])
         }
 
         // Sort the returned list by weight, with higher weighted planets being first
@@ -1223,7 +1228,7 @@ class MapOptions extends React.Component {
         return orderedPlanets
     }
 
-    getWeight(planetTileNumber, weights) {
+    getWeight(planetTileNumber, weights, ensuredAnomalies) {
         let total_weight = 0
         let tile = tileData.all[planetTileNumber.toString()]
 
@@ -1237,7 +1242,7 @@ class MapOptions extends React.Component {
         }
 
         // Handle anomalies
-        if (tile['type'] === 'anomaly') {
+        if (tile['type'] === 'red') {
             total_weight += weights['anomaly'] + 40;
             // Providing bonuses to these sections mean the other ones are never used
             // if (tile['anomaly'] === null
@@ -1248,6 +1253,7 @@ class MapOptions extends React.Component {
             // }
         }
         total_weight += tile['wormhole'] ? weights['wormhole'] : 0
+        total_weight += ensuredAnomalies.indexOf(planetTileNumber) > -1 ? weights['racial'] : 0
 
         return total_weight
     }

--- a/src/options/MapOptions.js
+++ b/src/options/MapOptions.js
@@ -669,7 +669,7 @@ class MapOptions extends React.Component {
         // These tiles are ensured for races and may not be replaced
         const ensuredAnomalies = [];
 
-        if(this.state.ensureRacialAnomalies) {
+        if(this.state.ensureRacialAnomalies && this.state.pickRaces) {
             currentRaces.forEach(race => {
                 let anomalies = []
                 let match = false;

--- a/src/options/MapOptions.js
+++ b/src/options/MapOptions.js
@@ -54,7 +54,7 @@ class MapOptions extends React.Component {
             pickMultipleRaces: false,
             shuffleBoards: false,
             reversePlacementOrder: false,
-            ensureRacialAnomalies: false,
+            ensureRacialAnomalies: true,
             generated: false,
 
             pickRacesHelp: false,
@@ -269,6 +269,7 @@ class MapOptions extends React.Component {
         encodedSettings += this.state.reversePlacementOrder ? "T" : "F";
         encodedSettings += this.state.pickRaces ? "T" : "F";
         if (this.state.pickRaces) {
+            encodedSettings += this.state.ensureRacialAnomalies ? "T" : "F";
             let combinedRaces = this.state.optionsPossible.races.concat(this.state.optionsPossible.pokRaces)
             if ((this.props.useProphecyOfKings === false && this.props.currentRaces.length !== this.state.optionsPossible.races.length) ||
                 (this.props.useProphecyOfKings === true && this.props.currentRaces.length !== combinedRaces.length)) {
@@ -360,7 +361,12 @@ class MapOptions extends React.Component {
 
         let currentPlayerNames = this.props.currentPlayerNames;
         let currentRaces = this.props.currentRaces;
+        let ensureRacialAnomalies = this.props.ensureRacialAnomalies;
         if (pickRaces) {
+            // Ensure Racial Anomalies
+            ensureRacialAnomalies = newSettings[currentIndex] === "T";
+            currentIndex += 1;
+            
             if (newSettings[currentIndex] !== "|") {
                 if (newSettings[currentIndex] !== undefined) {
                     // Custom races, but not all of them
@@ -396,6 +402,7 @@ class MapOptions extends React.Component {
             shuffleBoards: shuffleBoards,
             reversePlacementOrder: reversePlacementOrder,
             pickRaces: pickRaces,
+            ensureRacialAnomalies: ensureRacialAnomalies,
         }, () => {
             this.props.updateRaces(currentRaces);
             this.props.updatePlayerNames(currentPlayerNames);
@@ -1397,17 +1404,17 @@ class MapOptions extends React.Component {
                         <label className="custom-control-label" htmlFor="pickRaces">Pick Races for Players</label>
                         <QuestionCircle className="icon" onClick={this.togglePickRacesHelp} />
                     </div>
-                    <div className={"ml-2 collapse " + (this.state.pickRaces ? "show" : "")} id="pickRacesCollapse">
+                    <div className={"ml-2 mb-2 collapse " + (this.state.pickRaces ? "show" : "")} id="pickRacesCollapse">
                         <div className="card card-body">
                             <button type="button" className="btn btn-outline-primary mb-2" onClick={this.toggleSetRacesHelp}>Set Included Races</button>
 
                             <button type="button" className="btn btn-outline-primary mb-2" onClick={this.toggleSetPlayerNamesHelp}>Set Player Names</button>
-
-                            {/*<div className="custom-control custom-checkbox d-flex">*/}
-                            {/*    <input type="checkbox" className="custom-control-input" id="pickMultipleRaces" name="pickMultipleRaces" checked={this.state.pickMultipleRaces} onChange={this.handleInputChange} />*/}
-                            {/*    <label className="custom-control-label" htmlFor="pickMultipleRaces">Let Players Pick From Multiple</label>*/}
-                            {/*    <QuestionCircle className="icon" onClick={this.togglePickMultipleRacesHelp} />*/}
-                            {/*</div>*/}
+                            
+                            <div className="custom-control custom-checkbox d-flex">
+                                <input type="checkbox" className="custom-control-input" id="ensureRacialAnomalies" name="ensureRacialAnomalies" checked={this.state.ensureRacialAnomalies} onChange={this.handleInputChange} />
+                                <label className="custom-control-label" htmlFor="ensureRacialAnomalies">Ensure Racial Anomalies</label>
+                                <QuestionCircle className="icon" onClick={this.toggleEnsureRacialAnomaliesHelp} />
+                            </div>
                         </div>
                     </div>
 
@@ -1421,12 +1428,6 @@ class MapOptions extends React.Component {
                         <input type="checkbox" className="custom-control-input" id="reversePlacementOrder" name="reversePlacementOrder" checked={this.state.reversePlacementOrder} onChange={this.handleInputChange} />
                         <label className="custom-control-label" htmlFor="reversePlacementOrder">Reverse Placement Order</label>
                         <QuestionCircle className="icon" onClick={this.toggleReversePlacementOrderHelp} />
-                    </div>
-
-                    <div className="custom-control custom-checkbox mb-3 d-flex">
-                        <input type="checkbox" className="custom-control-input" id="ensureRacialAnomalies" name="ensureRacialAnomalies" checked={this.state.ensureRacialAnomalies} onChange={this.handleInputChange} />
-                        <label className="custom-control-label" htmlFor="ensureRacialAnomalies">Ensure Racial Anomalies</label>
-                        <QuestionCircle className="icon" onClick={this.toggleEnsureRacialAnomaliesHelp} />
                     </div>
 
                     <SetPlayerNameModal visible={this.state.setPlayerNamesHelp} currentPlayerNames={this.props.currentPlayerNames}


### PR DESCRIPTION
Adds an option to make sure racial anomalies are generated for races that benefit from them. Disabled by default. If enabled:
* The Clan of Saar get an asteroid field
* The Embers of Muaat get a supernova
* The Empyrean get a nebula
* The Vuil'Raith Cabal get a gravity rift