### PR TITLE
Sort extra tiles by system number

### DIFF
--- a/src/panels/ExtraTiles.js
+++ b/src/panels/ExtraTiles.js
@@ -36,6 +36,8 @@ class ExtraTiles extends React.Component {
             systemNumbers = [-1].concat(systemNumbers.concat(tileData.hyperlanes));
         }
 
+        systemNumbers.sort();
+
         const tileObjects = []
         for (let systemNumber of systemNumbers) {
 

--- a/src/panels/ExtraTiles.js
+++ b/src/panels/ExtraTiles.js
@@ -36,7 +36,31 @@ class ExtraTiles extends React.Component {
             systemNumbers = [-1].concat(systemNumbers.concat(tileData.hyperlanes));
         }
 
-        systemNumbers.sort();
+        function parseSystemNumber(systemNumber) {
+            if (typeof systemNumber == "number") {
+                return [systemNumber, ""];
+            } else {
+                const [, numberPart, stringPart] = systemNumber.match(/(\d+)(.*)/);
+                return [numberPart, stringPart];
+            }
+        }
+
+        function compareSystemNumbers(a, b) {
+            const [numberA, stringA] = parseSystemNumber(a);
+            const [numberB, stringB] = parseSystemNumber(b);
+            if (numberA === numberB) {
+                if (stringA < stringB) {
+                    return -1;
+                }
+                if (stringA === stringB) {
+                    return 0;
+                }
+                return 1;
+            }
+            return numberA - numberB;
+        }
+
+        systemNumbers.sort(compareSystemNumbers);
 
         const tileObjects = []
         for (let systemNumber of systemNumbers) {


### PR DESCRIPTION
Hi! Thanks for maintaining this wonderful map-builder.

This PR would sort the tiles in the extra-tiles display by their system number.

The preexisting order (base game blue, base game red, prophecy blue, prophecy red, hyperlanes) is very slightly different (tiles 67 and 68 are shifted) which can be pretty confusing.