### PR TITLE
Feature: Map Rotation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -221,33 +221,42 @@ h1, h2, h3, h4, h5 {
 #zoomButtons .btn:focus {
     box-shadow: none;
 }
+#rotateButtons {
+    position: fixed;
+    top: calc(var(--title-height)  + 60px);
+    right: calc(var(--options-width) + var(--scroll-bar-distance));
+    z-index: 1002;
+}
+#rotateButtons .btn:focus {
+    box-shadow: none;
+}
 #hexOverlay {
     position: fixed;
-    top: calc(var(--title-height) + 60px);
+    top: calc(var(--title-height) + 120px);
     right: calc(var(--options-width) + var(--scroll-bar-distance));
     z-index: 1002;
 }
 #extraTilesButton {
     position: fixed;
-    top: calc(var(--title-height) + 95px);
+    top: calc(var(--title-height) + 155px);
     right: calc(var(--options-width) + var(--scroll-bar-distance));
     z-index: 1002;
 }
 #moreInfoButton {
     position: fixed;
-    top: calc(var(--title-height) + 130px);
+    top: calc(var(--title-height) + 190px);
     right: calc(var(--options-width) + var(--scroll-bar-distance));
     z-index: 1002;
 }
 #shareMapButton {
     position: fixed;
-    top: calc(var(--title-height) + 165px);
+    top: calc(var(--title-height) + 225px);
     right: calc(var(--options-width) + var(--scroll-bar-distance));
     z-index: 1002;
 }
 #loadMapButton {
     position: fixed;
-    top: calc(var(--title-height) + 200px);
+    top: calc(var(--title-height) + 260px);
     right: calc(var(--options-width) + var(--scroll-bar-distance));
     z-index: 1002;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -567,117 +567,133 @@ class App extends React.Component {
         }
     }
 
-    generateRotatedMap(rotations = 1) {
-        // Performs a single map rotation. Supports up to 4 rows/rings.
-        let rotateTileArray = (tilesOverride = []) => {
-            let rotatedTileArray = [];
+    /**
+     * Performs a single rotation of the tiles that make up the hex grid.
+     * Supports up to 4 rings. 
+     */
+    rotateHexGrid(tilesOverride = []) {
+        let rotatedTileArray = [];
 
-            // Central tile.
-            rotatedTileArray.push(tilesOverride[0] ?? this.state.tiles[0]);
+        // Central tile.
+        rotatedTileArray.push(tilesOverride[0] ?? this.state.tiles[0]);
 
-            // First row of tiles.
-            rotatedTileArray.push(tilesOverride[6] ?? this.state.tiles[6]);
-            rotatedTileArray.push(tilesOverride[1] ?? this.state.tiles[1]);
-            rotatedTileArray.push(tilesOverride[2] ?? this.state.tiles[2]);
-            rotatedTileArray.push(tilesOverride[3] ?? this.state.tiles[3]);
-            rotatedTileArray.push(tilesOverride[4] ?? this.state.tiles[4]);
-            rotatedTileArray.push(tilesOverride[5] ?? this.state.tiles[5]);
+        // First ring of tiles.
+        rotatedTileArray.push(tilesOverride[6] ?? this.state.tiles[6]);
+        rotatedTileArray.push(tilesOverride[1] ?? this.state.tiles[1]);
+        rotatedTileArray.push(tilesOverride[2] ?? this.state.tiles[2]);
+        rotatedTileArray.push(tilesOverride[3] ?? this.state.tiles[3]);
+        rotatedTileArray.push(tilesOverride[4] ?? this.state.tiles[4]);
+        rotatedTileArray.push(tilesOverride[5] ?? this.state.tiles[5]);
 
-            // Second row of tiles.
-            rotatedTileArray.push(tilesOverride[17] ?? this.state.tiles[17]);
-            rotatedTileArray.push(tilesOverride[18] ?? this.state.tiles[18]);
-            rotatedTileArray.push(tilesOverride[7] ?? this.state.tiles[7]);
-            rotatedTileArray.push(tilesOverride[8] ?? this.state.tiles[8]);
-            rotatedTileArray.push(tilesOverride[9] ?? this.state.tiles[9]);
-            rotatedTileArray.push(tilesOverride[10] ?? this.state.tiles[10]);
-            rotatedTileArray.push(tilesOverride[11] ?? this.state.tiles[11]);
-            rotatedTileArray.push(tilesOverride[12] ?? this.state.tiles[12]);
-            rotatedTileArray.push(tilesOverride[13] ?? this.state.tiles[13]);
-            rotatedTileArray.push(tilesOverride[14] ?? this.state.tiles[14]);
-            rotatedTileArray.push(tilesOverride[15] ?? this.state.tiles[15]);
-            rotatedTileArray.push(tilesOverride[16] ?? this.state.tiles[16]);
+        // Second ring of tiles.
+        rotatedTileArray.push(tilesOverride[17] ?? this.state.tiles[17]);
+        rotatedTileArray.push(tilesOverride[18] ?? this.state.tiles[18]);
+        rotatedTileArray.push(tilesOverride[7] ?? this.state.tiles[7]);
+        rotatedTileArray.push(tilesOverride[8] ?? this.state.tiles[8]);
+        rotatedTileArray.push(tilesOverride[9] ?? this.state.tiles[9]);
+        rotatedTileArray.push(tilesOverride[10] ?? this.state.tiles[10]);
+        rotatedTileArray.push(tilesOverride[11] ?? this.state.tiles[11]);
+        rotatedTileArray.push(tilesOverride[12] ?? this.state.tiles[12]);
+        rotatedTileArray.push(tilesOverride[13] ?? this.state.tiles[13]);
+        rotatedTileArray.push(tilesOverride[14] ?? this.state.tiles[14]);
+        rotatedTileArray.push(tilesOverride[15] ?? this.state.tiles[15]);
+        rotatedTileArray.push(tilesOverride[16] ?? this.state.tiles[16]);
 
-            // Third row of tiles.
-            rotatedTileArray.push(tilesOverride[34] ?? this.state.tiles[34]);
-            rotatedTileArray.push(tilesOverride[35] ?? this.state.tiles[35]);
-            rotatedTileArray.push(tilesOverride[36] ?? this.state.tiles[36]);
-            rotatedTileArray.push(tilesOverride[19] ?? this.state.tiles[19]);
-            rotatedTileArray.push(tilesOverride[20] ?? this.state.tiles[20]);
-            rotatedTileArray.push(tilesOverride[21] ?? this.state.tiles[21]);
-            rotatedTileArray.push(tilesOverride[22] ?? this.state.tiles[22]);
-            rotatedTileArray.push(tilesOverride[23] ?? this.state.tiles[23]);
-            rotatedTileArray.push(tilesOverride[24] ?? this.state.tiles[24]);
-            rotatedTileArray.push(tilesOverride[25] ?? this.state.tiles[25]);
-            rotatedTileArray.push(tilesOverride[26] ?? this.state.tiles[26]);
-            rotatedTileArray.push(tilesOverride[27] ?? this.state.tiles[27]);
-            rotatedTileArray.push(tilesOverride[28] ?? this.state.tiles[28]);
-            rotatedTileArray.push(tilesOverride[29] ?? this.state.tiles[29]);
-            rotatedTileArray.push(tilesOverride[30] ?? this.state.tiles[30]);
-            rotatedTileArray.push(tilesOverride[31] ?? this.state.tiles[31]);
-            rotatedTileArray.push(tilesOverride[32] ?? this.state.tiles[32]);
-            rotatedTileArray.push(tilesOverride[33] ?? this.state.tiles[33]);
+        // Third ring of tiles.
+        rotatedTileArray.push(tilesOverride[34] ?? this.state.tiles[34]);
+        rotatedTileArray.push(tilesOverride[35] ?? this.state.tiles[35]);
+        rotatedTileArray.push(tilesOverride[36] ?? this.state.tiles[36]);
+        rotatedTileArray.push(tilesOverride[19] ?? this.state.tiles[19]);
+        rotatedTileArray.push(tilesOverride[20] ?? this.state.tiles[20]);
+        rotatedTileArray.push(tilesOverride[21] ?? this.state.tiles[21]);
+        rotatedTileArray.push(tilesOverride[22] ?? this.state.tiles[22]);
+        rotatedTileArray.push(tilesOverride[23] ?? this.state.tiles[23]);
+        rotatedTileArray.push(tilesOverride[24] ?? this.state.tiles[24]);
+        rotatedTileArray.push(tilesOverride[25] ?? this.state.tiles[25]);
+        rotatedTileArray.push(tilesOverride[26] ?? this.state.tiles[26]);
+        rotatedTileArray.push(tilesOverride[27] ?? this.state.tiles[27]);
+        rotatedTileArray.push(tilesOverride[28] ?? this.state.tiles[28]);
+        rotatedTileArray.push(tilesOverride[29] ?? this.state.tiles[29]);
+        rotatedTileArray.push(tilesOverride[30] ?? this.state.tiles[30]);
+        rotatedTileArray.push(tilesOverride[31] ?? this.state.tiles[31]);
+        rotatedTileArray.push(tilesOverride[32] ?? this.state.tiles[32]);
+        rotatedTileArray.push(tilesOverride[33] ?? this.state.tiles[33]);
 
-            // Fourth row of tiles?
-            if (this.state.tiles.length > 37) {
-                rotatedTileArray.push(tilesOverride[57] ?? this.state.tiles[57]);
-                rotatedTileArray.push(tilesOverride[58] ?? this.state.tiles[58]);
-                rotatedTileArray.push(tilesOverride[59] ?? this.state.tiles[59]);
-                rotatedTileArray.push(tilesOverride[60] ?? this.state.tiles[60]);
-                rotatedTileArray.push(tilesOverride[37] ?? this.state.tiles[37]);
-                rotatedTileArray.push(tilesOverride[38] ?? this.state.tiles[38]);
-                rotatedTileArray.push(tilesOverride[39] ?? this.state.tiles[39]);
-                rotatedTileArray.push(tilesOverride[40] ?? this.state.tiles[40]);
-                rotatedTileArray.push(tilesOverride[41] ?? this.state.tiles[41]);
-                rotatedTileArray.push(tilesOverride[42] ?? this.state.tiles[42]);
-                rotatedTileArray.push(tilesOverride[43] ?? this.state.tiles[43]);
-                rotatedTileArray.push(tilesOverride[44] ?? this.state.tiles[44]);
-                rotatedTileArray.push(tilesOverride[45] ?? this.state.tiles[45]);
-                rotatedTileArray.push(tilesOverride[46] ?? this.state.tiles[46]);
-                rotatedTileArray.push(tilesOverride[47] ?? this.state.tiles[47]);
-                rotatedTileArray.push(tilesOverride[48] ?? this.state.tiles[48]);
-                rotatedTileArray.push(tilesOverride[49] ?? this.state.tiles[49]);
-                rotatedTileArray.push(tilesOverride[50] ?? this.state.tiles[50]);
-                rotatedTileArray.push(tilesOverride[51] ?? this.state.tiles[51]);
-                rotatedTileArray.push(tilesOverride[52] ?? this.state.tiles[52]);
-                rotatedTileArray.push(tilesOverride[53] ?? this.state.tiles[53]);
-                rotatedTileArray.push(tilesOverride[54] ?? this.state.tiles[54]);
-                rotatedTileArray.push(tilesOverride[55] ?? this.state.tiles[55]);
-                rotatedTileArray.push(tilesOverride[56] ?? this.state.tiles[56]);
-            }
-
-            return rotatedTileArray;
+        // Fourth ring of tiles?
+        if (this.state.tiles.length > 37) {
+            rotatedTileArray.push(tilesOverride[57] ?? this.state.tiles[57]);
+            rotatedTileArray.push(tilesOverride[58] ?? this.state.tiles[58]);
+            rotatedTileArray.push(tilesOverride[59] ?? this.state.tiles[59]);
+            rotatedTileArray.push(tilesOverride[60] ?? this.state.tiles[60]);
+            rotatedTileArray.push(tilesOverride[37] ?? this.state.tiles[37]);
+            rotatedTileArray.push(tilesOverride[38] ?? this.state.tiles[38]);
+            rotatedTileArray.push(tilesOverride[39] ?? this.state.tiles[39]);
+            rotatedTileArray.push(tilesOverride[40] ?? this.state.tiles[40]);
+            rotatedTileArray.push(tilesOverride[41] ?? this.state.tiles[41]);
+            rotatedTileArray.push(tilesOverride[42] ?? this.state.tiles[42]);
+            rotatedTileArray.push(tilesOverride[43] ?? this.state.tiles[43]);
+            rotatedTileArray.push(tilesOverride[44] ?? this.state.tiles[44]);
+            rotatedTileArray.push(tilesOverride[45] ?? this.state.tiles[45]);
+            rotatedTileArray.push(tilesOverride[46] ?? this.state.tiles[46]);
+            rotatedTileArray.push(tilesOverride[47] ?? this.state.tiles[47]);
+            rotatedTileArray.push(tilesOverride[48] ?? this.state.tiles[48]);
+            rotatedTileArray.push(tilesOverride[49] ?? this.state.tiles[49]);
+            rotatedTileArray.push(tilesOverride[50] ?? this.state.tiles[50]);
+            rotatedTileArray.push(tilesOverride[51] ?? this.state.tiles[51]);
+            rotatedTileArray.push(tilesOverride[52] ?? this.state.tiles[52]);
+            rotatedTileArray.push(tilesOverride[53] ?? this.state.tiles[53]);
+            rotatedTileArray.push(tilesOverride[54] ?? this.state.tiles[54]);
+            rotatedTileArray.push(tilesOverride[55] ?? this.state.tiles[55]);
+            rotatedTileArray.push(tilesOverride[56] ?? this.state.tiles[56]);
         }
 
-        // Rotate the map the specified number of times.
-        let rotatedTileArray = [];
+        return rotatedTileArray;
+    }
+
+    /**
+     * Returns a tile array where all hyperlanes tiles have been rotated clockwise.
+     */
+    rotateHyperlaneTiles(tileArray, rotations = 1) {
         const hyperlaneTiles = ["83A","83B","84A","84B","85A","85B","86A","86B","87A","87B","88A","88B","89A","89B","90A","90B","91A","91B"];
+        const updatedTileArray = [...tileArray];
+
+        // Iterate through all tiles and rotate the hyperlanes by N rotations.
+        for (let j = 0; j < updatedTileArray.length; j++) {
+            // Coerce all the tiles to strings for easier checking.
+            const tile = updatedTileArray[j] + "";
+
+            if (hyperlaneTiles.includes(tile.split('-')[0])) {
+                // Check if the tile already has any rotation.
+                const hasRotation = tile.includes('-');
+
+                let newRotation = 1;
+                if (hasRotation) {
+                    const currentRotation = parseInt(tile.split('-')[1]);
+                    newRotation = (currentRotation + rotations) % 6;
+                }
+
+                updatedTileArray[j] = `${tile.split('-')[0]}-${newRotation}`;
+            }
+        }
+
+        return updatedTileArray;
+    }
+
+    /**
+     * Returns a rotated version of the current map.
+     */
+    generateRotatedMap(rotations = 1) {
+        let rotatedTileArray = [];
         for (let i = 0; i < rotations; i++) {
-            if (i == 0) {
+            if (i === 0) {
                 // Use the current map for the first rotation.
-                rotatedTileArray = rotateTileArray();
+                rotatedTileArray = this.rotateHexGrid();
             } else {
                 // Pass the previously rotated map for subsequent iterations.
-                rotatedTileArray = rotateTileArray(rotatedTileArray);
+                rotatedTileArray = this.rotateHexGrid(rotatedTileArray);
             }
 
-            // Iterate through all tiles and rotate the hyperlanes by one.
-            for (let j = 0; j < rotatedTileArray.length; j++) {
-                // Coerce all the tiles to strings for easier checking.
-                const tile = rotatedTileArray[j] + "";
-
-                if (hyperlaneTiles.includes(tile.split('-')[0])) {
-                    // Check if the tile already has any rotation.
-                    const hasRotation = tile.includes('-');
-
-                    let newRotation = 1;
-                    if (hasRotation) {
-                        const currentRotation = parseInt(tile.split('-')[1]);
-                        newRotation = (currentRotation + 1) % 6;
-                    }
-
-                    rotatedTileArray[j] = `${tile.split('-')[0]}-${newRotation}`;
-                }
-            }
+            rotatedTileArray = this.rotateHyperlaneTiles(rotatedTileArray);
         }
         return rotatedTileArray;
     }
@@ -686,7 +702,6 @@ class App extends React.Component {
      * Rotates the map in a clockwise direction.
      */
     rotateClockwise() {
-        // console.log(this.state.tiles);
         // Update the tile string
         this.setState({
             tileClicked: -1,

--- a/src/App.js
+++ b/src/App.js
@@ -654,25 +654,22 @@ class App extends React.Component {
      * Returns a tile array where all hyperlanes tiles have been rotated clockwise.
      */
     rotateHyperlaneTiles(tileArray, rotations = 1) {
-        const hyperlaneTiles = ["83A","83B","84A","84B","85A","85B","86A","86B","87A","87B","88A","88B","89A","89B","90A","90B","91A","91B"];
         const updatedTileArray = [...tileArray];
 
         // Iterate through all tiles and rotate the hyperlanes by N rotations.
         for (let j = 0; j < updatedTileArray.length; j++) {
-            // Coerce all the tiles to strings for easier checking.
-            const tile = updatedTileArray[j] + "";
-
-            if (hyperlaneTiles.includes(tile.split('-')[0])) {
+            // Only hyperlane tiles are strings / aren't numbers.
+            if (typeof updatedTileArray[j] === "string") {
                 // Check if the tile already has any rotation.
-                const hasRotation = tile.includes('-');
+                const hasRotation = updatedTileArray[j].includes('-');
 
                 let newRotation = 1;
                 if (hasRotation) {
-                    const currentRotation = parseInt(tile.split('-')[1]);
+                    const currentRotation = parseInt(updatedTileArray[j].split('-')[1]);
                     newRotation = (currentRotation + rotations) % 6;
                 }
 
-                updatedTileArray[j] = `${tile.split('-')[0]}-${newRotation}`;
+                updatedTileArray[j] = `${updatedTileArray[j].split('-')[0]}-${newRotation}`;
             }
         }
 

--- a/src/App.js
+++ b/src/App.js
@@ -681,6 +681,8 @@ class App extends React.Component {
      */
     generateRotatedMap(rotations = 1) {
         let rotatedTileArray = [];
+
+        // Rotate the hex grid the required number of times.
         for (let i = 0; i < rotations; i++) {
             if (i === 0) {
                 // Use the current map for the first rotation.
@@ -690,8 +692,10 @@ class App extends React.Component {
                 rotatedTileArray = this.rotateHexGrid(rotatedTileArray);
             }
 
+            // Rotate the hyperlane tiles so that connections are preserved.
             rotatedTileArray = this.rotateHyperlaneTiles(rotatedTileArray);
         }
+
         return rotatedTileArray;
     }
 

--- a/src/App.js
+++ b/src/App.js
@@ -84,6 +84,8 @@ class App extends React.Component {
         this.zoomScroll = this.zoomScroll.bind(this);
         this.zoomPlusClick = this.zoomPlusClick.bind(this);
         this.zoomMinusClick = this.zoomMinusClick.bind(this);
+        this.rotateClockwise = this.rotateClockwise.bind(this);
+        this.rotateCounterClockwise = this.rotateCounterClockwise.bind(this);
         
         this.drag = this.drag.bind(this);
         this.drop = this.drop.bind(this);
@@ -565,6 +567,125 @@ class App extends React.Component {
         }
     }
 
+    generateRotatedMap(rotations = 1) {
+        // Performs a single map rotation. Supports up to 4 rows/rings.
+        let rotateTileArray = (tilesOverride = []) => {
+            let rotatedTileArray = [];
+
+            // Central tile.
+            rotatedTileArray.push(tilesOverride[0] ?? this.state.tiles[0]);
+
+            // First row of tiles.
+            rotatedTileArray.push(tilesOverride[6] ?? this.state.tiles[6]);
+            rotatedTileArray.push(tilesOverride[1] ?? this.state.tiles[1]);
+            rotatedTileArray.push(tilesOverride[2] ?? this.state.tiles[2]);
+            rotatedTileArray.push(tilesOverride[3] ?? this.state.tiles[3]);
+            rotatedTileArray.push(tilesOverride[4] ?? this.state.tiles[4]);
+            rotatedTileArray.push(tilesOverride[5] ?? this.state.tiles[5]);
+
+            // Second row of tiles.
+            rotatedTileArray.push(tilesOverride[17] ?? this.state.tiles[17]);
+            rotatedTileArray.push(tilesOverride[18] ?? this.state.tiles[18]);
+            rotatedTileArray.push(tilesOverride[7] ?? this.state.tiles[7]);
+            rotatedTileArray.push(tilesOverride[8] ?? this.state.tiles[8]);
+            rotatedTileArray.push(tilesOverride[9] ?? this.state.tiles[9]);
+            rotatedTileArray.push(tilesOverride[10] ?? this.state.tiles[10]);
+            rotatedTileArray.push(tilesOverride[11] ?? this.state.tiles[11]);
+            rotatedTileArray.push(tilesOverride[12] ?? this.state.tiles[12]);
+            rotatedTileArray.push(tilesOverride[13] ?? this.state.tiles[13]);
+            rotatedTileArray.push(tilesOverride[14] ?? this.state.tiles[14]);
+            rotatedTileArray.push(tilesOverride[15] ?? this.state.tiles[15]);
+            rotatedTileArray.push(tilesOverride[16] ?? this.state.tiles[16]);
+
+            // Third row of tiles.
+            rotatedTileArray.push(tilesOverride[34] ?? this.state.tiles[34]);
+            rotatedTileArray.push(tilesOverride[35] ?? this.state.tiles[35]);
+            rotatedTileArray.push(tilesOverride[36] ?? this.state.tiles[36]);
+            rotatedTileArray.push(tilesOverride[19] ?? this.state.tiles[19]);
+            rotatedTileArray.push(tilesOverride[20] ?? this.state.tiles[20]);
+            rotatedTileArray.push(tilesOverride[21] ?? this.state.tiles[21]);
+            rotatedTileArray.push(tilesOverride[22] ?? this.state.tiles[22]);
+            rotatedTileArray.push(tilesOverride[23] ?? this.state.tiles[23]);
+            rotatedTileArray.push(tilesOverride[24] ?? this.state.tiles[24]);
+            rotatedTileArray.push(tilesOverride[25] ?? this.state.tiles[25]);
+            rotatedTileArray.push(tilesOverride[26] ?? this.state.tiles[26]);
+            rotatedTileArray.push(tilesOverride[27] ?? this.state.tiles[27]);
+            rotatedTileArray.push(tilesOverride[28] ?? this.state.tiles[28]);
+            rotatedTileArray.push(tilesOverride[29] ?? this.state.tiles[29]);
+            rotatedTileArray.push(tilesOverride[30] ?? this.state.tiles[30]);
+            rotatedTileArray.push(tilesOverride[31] ?? this.state.tiles[31]);
+            rotatedTileArray.push(tilesOverride[32] ?? this.state.tiles[32]);
+            rotatedTileArray.push(tilesOverride[33] ?? this.state.tiles[33]);
+
+            // Fourth row of tiles?
+            if (this.state.tiles.length > 37) {
+                rotatedTileArray.push(tilesOverride[57] ?? this.state.tiles[57]);
+                rotatedTileArray.push(tilesOverride[58] ?? this.state.tiles[58]);
+                rotatedTileArray.push(tilesOverride[59] ?? this.state.tiles[59]);
+                rotatedTileArray.push(tilesOverride[60] ?? this.state.tiles[60]);
+                rotatedTileArray.push(tilesOverride[37] ?? this.state.tiles[37]);
+                rotatedTileArray.push(tilesOverride[38] ?? this.state.tiles[38]);
+                rotatedTileArray.push(tilesOverride[39] ?? this.state.tiles[39]);
+                rotatedTileArray.push(tilesOverride[40] ?? this.state.tiles[40]);
+                rotatedTileArray.push(tilesOverride[41] ?? this.state.tiles[41]);
+                rotatedTileArray.push(tilesOverride[42] ?? this.state.tiles[42]);
+                rotatedTileArray.push(tilesOverride[43] ?? this.state.tiles[43]);
+                rotatedTileArray.push(tilesOverride[44] ?? this.state.tiles[44]);
+                rotatedTileArray.push(tilesOverride[45] ?? this.state.tiles[45]);
+                rotatedTileArray.push(tilesOverride[46] ?? this.state.tiles[46]);
+                rotatedTileArray.push(tilesOverride[47] ?? this.state.tiles[47]);
+                rotatedTileArray.push(tilesOverride[48] ?? this.state.tiles[48]);
+                rotatedTileArray.push(tilesOverride[49] ?? this.state.tiles[49]);
+                rotatedTileArray.push(tilesOverride[50] ?? this.state.tiles[50]);
+                rotatedTileArray.push(tilesOverride[51] ?? this.state.tiles[51]);
+                rotatedTileArray.push(tilesOverride[52] ?? this.state.tiles[52]);
+                rotatedTileArray.push(tilesOverride[53] ?? this.state.tiles[53]);
+                rotatedTileArray.push(tilesOverride[54] ?? this.state.tiles[54]);
+                rotatedTileArray.push(tilesOverride[55] ?? this.state.tiles[55]);
+                rotatedTileArray.push(tilesOverride[56] ?? this.state.tiles[56]);
+            }
+
+            return rotatedTileArray;
+        }
+
+        // Rotate the map the specified number of times.
+        let rotatedTileArray = [];
+        for (let i = 0; i < rotations; i++) {
+            if (i == 0) {
+                // Use the current map for the first rotation.
+                rotatedTileArray = rotateTileArray();
+            } else {
+                // Pass the previously rotated map for subsequent iterations.
+                rotatedTileArray = rotateTileArray(rotatedTileArray);
+            }
+        }
+        return rotatedTileArray;
+    }
+
+    /**
+     * Rotates the map in a clockwise direction.
+     */
+    rotateClockwise() {
+        // Update the tile string
+        this.setState({
+            tileClicked: -1,
+        }, () => {
+            this.updateTiles(this.generateRotatedMap(), undefined, false, true);
+        } );
+    }
+
+    /**
+     * Rotates the map in a counter-clockwise direction.
+     */
+    rotateCounterClockwise() {
+        // Update the tile string
+        this.setState({
+            tileClicked: -1,
+        }, () => {
+            this.updateTiles(this.generateRotatedMap(5), undefined, false, true);
+        } );
+    }
+
     updateRaces(races) {
         this.setState({
             currentRaces: races,
@@ -934,6 +1055,7 @@ class App extends React.Component {
                              toggleOverlay={this.toggleOverlay}
                              toggleMoreInfo={this.toggleMoreInfo} toggleExtraTiles={this.toggleExtraTiles}
                              zoomPlus={this.zoomPlusClick} zoomMinus={this.zoomMinusClick}
+                             rotateClockwise={this.rotateClockwise} rotateCounterClockwise={this.rotateCounterClockwise}
                              toggleBackground={this.toggleBackground} updateTiles={this.updateTiles}
                              removeTrailing={this.removeTrailing}
                 />

--- a/src/App.js
+++ b/src/App.js
@@ -650,6 +650,7 @@ class App extends React.Component {
 
         // Rotate the map the specified number of times.
         let rotatedTileArray = [];
+        const hyperlaneTiles = ["83A","83B","84A","84B","85A","85B","86A","86B","87A","87B","88A","88B","89A","89B","90A","90B","91A","91B"];
         for (let i = 0; i < rotations; i++) {
             if (i == 0) {
                 // Use the current map for the first rotation.
@@ -657,6 +658,25 @@ class App extends React.Component {
             } else {
                 // Pass the previously rotated map for subsequent iterations.
                 rotatedTileArray = rotateTileArray(rotatedTileArray);
+            }
+
+            // Iterate through all tiles and rotate the hyperlanes by one.
+            for (let j = 0; j < rotatedTileArray.length; j++) {
+                // Coerce all the tiles to strings for easier checking.
+                const tile = rotatedTileArray[j] + "";
+
+                if (hyperlaneTiles.includes(tile.split('-')[0])) {
+                    // Check if the tile already has any rotation.
+                    const hasRotation = tile.includes('-');
+
+                    let newRotation = 1;
+                    if (hasRotation) {
+                        const currentRotation = parseInt(tile.split('-')[1]);
+                        newRotation = (currentRotation + 1) % 6;
+                    }
+
+                    rotatedTileArray[j] = `${tile.split('-')[0]}-${newRotation}`;
+                }
             }
         }
         return rotatedTileArray;
@@ -666,6 +686,7 @@ class App extends React.Component {
      * Rotates the map in a clockwise direction.
      */
     rotateClockwise() {
+        // console.log(this.state.tiles);
         // Update the tile string
         this.setState({
             tileClicked: -1,

--- a/src/map/MapControls.js
+++ b/src/map/MapControls.js
@@ -50,10 +50,10 @@ class MapControls extends React.Component {
                 </div>
 
                 <div id="rotateButtons" className={"btn-group-justified btn-group-sm btn-group-vertical" + (this.props.visible ? "" : " d-none")}>
-                    <button className="btn btn-primary" id="rotateLeft" onClick={this.props.zoomPlus} data-place="left" >
+                    <button className="btn btn-primary" id="rotateClockwise" onClick={this.props.rotateClockwise} data-place="left" >
                         <ArrowClockwise className="icon" />
                     </button>
-                    <button className="btn btn-primary" id="rotateRight" onClick={this.props.zoomMinus}>
+                    <button className="btn btn-primary" id="rotateCounterClockwise" onClick={this.props.rotateCounterClockwise}>
                         <ArrowCounterclockwise className="icon" />
                     </button>
                 </div>

--- a/src/map/MapControls.js
+++ b/src/map/MapControls.js
@@ -50,14 +50,14 @@ class MapControls extends React.Component {
                 </div>
 
                 <div id="rotateButtons" className={"btn-group-justified btn-group-sm btn-group-vertical" + (this.props.visible ? "" : " d-none")}>
-                    <button className="btn btn-primary" id="rotateClockwise" onClick={this.props.rotateClockwise} data-place="left" >
+                    <button className="btn btn-primary" id="rotateClockwise" onClick={this.props.rotateClockwise} data-tip="Rotate Map Clockwise" data-place="left" >
                         <ArrowClockwise className="icon" />
                     </button>
-                    <button className="btn btn-primary" id="rotateCounterClockwise" onClick={this.props.rotateCounterClockwise}>
+                    <button className="btn btn-primary" id="rotateCounterClockwise" onClick={this.props.rotateCounterClockwise} data-tip="Rotate Map Counter-Clockwise" data-place="left" >
                         <ArrowCounterclockwise className="icon" />
                     </button>
                 </div>
-    
+
                 <div id="hexOverlay" className={"btn-group-justified btn-group-sm" + (this.props.visible ? "" : " d-none")} onClick={this.props.toggleOverlay}>
                     <button className={"btn btn-primary" + (this.props.overlayVisible ? " active": "")} id="showHexOverlay" data-tip="Tile Number Overlay" data-place="left" >
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 194.78 169.62" className="icon" fill="currentColor">
@@ -66,7 +66,7 @@ class MapControls extends React.Component {
                         </svg>
                     </button>
                 </div>
-    
+
                 <div id="extraTilesButton" className={"btn-group-justified btn-group-sm" + (this.props.visible ? "" : " d-none")} onClick={this.props.toggleExtraTiles}>
                     <button className={"btn btn-primary" + (this.props.extraTilesVisible ? " active": "")} id="showExtraTiles" data-tip="Unused Tiles" data-place="left" >
                         <svg id="showExtraTilesSvg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 359.35 311.21" className="icon" fill="currentColor">

--- a/src/map/MapControls.js
+++ b/src/map/MapControls.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {CardImage, Dash, InfoCircle, Plus, Share, Upload} from "react-bootstrap-icons";
+import {Arrow90degLeft, Arrow90degRight, CardImage, Dash, InfoCircle, Plus, Share, Upload} from "react-bootstrap-icons";
 import ShareMapModal from "./ShareMapModal";
 import LoadMapModal from "./LoadMapModal";
 
@@ -46,6 +46,15 @@ class MapControls extends React.Component {
                     </button>
                     <button className="btn btn-primary" id="zoomMinus" onClick={this.props.zoomMinus}>
                         <Dash className="icon" />
+                    </button>
+                </div>
+
+                <div id="rotateButtons" className={"btn-group-justified btn-group-sm btn-group-vertical" + (this.props.visible ? "" : " d-none")}>
+                    <button className="btn btn-primary" id="rotateLeft" onClick={this.props.zoomPlus} data-place="left" >
+                        <Arrow90degLeft className="icon" />
+                    </button>
+                    <button className="btn btn-primary" id="rotateRight" onClick={this.props.zoomMinus}>
+                        <Arrow90degRight className="icon" />
                     </button>
                 </div>
     

--- a/src/map/MapControls.js
+++ b/src/map/MapControls.js
@@ -1,5 +1,5 @@
 import React from "react";
-import {Arrow90degLeft, Arrow90degRight, CardImage, Dash, InfoCircle, Plus, Share, Upload} from "react-bootstrap-icons";
+import {ArrowClockwise, ArrowCounterclockwise, CardImage, Dash, InfoCircle, Plus, Share, Upload} from "react-bootstrap-icons";
 import ShareMapModal from "./ShareMapModal";
 import LoadMapModal from "./LoadMapModal";
 
@@ -51,10 +51,10 @@ class MapControls extends React.Component {
 
                 <div id="rotateButtons" className={"btn-group-justified btn-group-sm btn-group-vertical" + (this.props.visible ? "" : " d-none")}>
                     <button className="btn btn-primary" id="rotateLeft" onClick={this.props.zoomPlus} data-place="left" >
-                        <Arrow90degLeft className="icon" />
+                        <ArrowClockwise className="icon" />
                     </button>
                     <button className="btn btn-primary" id="rotateRight" onClick={this.props.zoomMinus}>
-                        <Arrow90degRight className="icon" />
+                        <ArrowCounterclockwise className="icon" />
                     </button>
                 </div>
     


### PR DESCRIPTION
I found myself wanting to rotate a map today to share ahead of a game, and figured it might be fun to add the functionality to the site! Thanks for making this open-sourced!

I know there are some more dynamic ways to rotate the arrays, but with a maximum of 4 rings that I could see, I didn't think it was worth the added complexity and brain power. 😅

I did have a quick look through the rest of the source, and I'm hoping I haven't missed anything (e.g., URL updates, etc.). Currently, the player positions/names don't rotate with the board, but I'm sure that wouldn't be too much effort to add if that was preferred.

Edit: I did have to do some `npm audit fix`'ing to get the repo working on my local machine, but I haven't committed any of these updates.