### PR TITLE
Display player's race and starting map tile

### DIFF
--- a/src/panels/MoreInfo.js
+++ b/src/panels/MoreInfo.js
@@ -1,6 +1,7 @@
 import React from "react";
 import adjacencyData from "../data/adjacencyData.json";
 import tileData, {WORMHOLE_SYMBOLS} from "../data/tileData";
+import raceData from "../data/raceData.json";
 
 import influence from './icons/influence.png';
 import planet from './icons/planet.png';
@@ -109,6 +110,7 @@ class MoreInfo extends React.Component {
                 moreInfoByPlayer.push(
                     <tr key={"more-info-" + playerName} >
                         <th scope="row">{playerName}</th>
+                        <td>{raceData.homeSystemToRaceMap[this.props.tiles[tileNumber]]}<br />Home Tile: {this.props.tiles[tileNumber]}</td>
                         <td>{adjacentInfo.resources}</td>
                         <td>{adjacentInfo.influence}</td>
                         <td>
@@ -142,6 +144,7 @@ class MoreInfo extends React.Component {
                         <thead>
                             <tr>
                                 <th scope="col"></th>
+                                <th scope="col">Race</th>
                                 <th scope="col"><img className={"icon"} src={resource} alt={"Res."}/></th>
                                 <th scope="col"><img className={"icon"} src={influence} alt={"Inf."}/></th>
                                 <th scope="col"><img className={"icon"} src={planet} alt={"Planets"}/></th>


### PR DESCRIPTION
As a person who doesn't get to play Twilight Imperium 4 very often, I have difficulty in immediately realizing what race icon maps each race. This change adds support for displaying the race assignments and starting home tile. 

![image](https://github.com/user-attachments/assets/7386f519-f789-4a92-bf7d-a0166f498d49)
