### PR TITLE
Fix tts import/export when mecatol rex is not in the center of the galaxy (eg. Magi's Madness)

### DIFF
--- a/src/map/LoadMapModal.js
+++ b/src/map/LoadMapModal.js
@@ -27,8 +27,8 @@ class LoadMapModal extends React.Component {
         inputTiles = inputTiles.toString();
         inputTiles = inputTiles.split(" ")
 
-        // Add m-rex to the front, which TTS doesn't include
-        inputTiles.unshift("18")
+        // Add m-rex to the front, which TTS doesn't include (Unless m-rex is not in the center)
+        if(!inputTiles.includes("18")) inputTiles.unshift("18")
 
         inputTiles = inputTiles.map((value, index) => {
             let newValue = value

--- a/src/map/ShareMapModal.js
+++ b/src/map/ShareMapModal.js
@@ -25,8 +25,8 @@ class ShareMapModal extends React.Component {
         let tileString = [...this.props.tiles];
         tileString = this.removeTrailing(tileString);
 
-        // Remove mecatol rex
-        tileString.shift();
+        // Remove mecatol rex if it's in the center
+        if(tileString[0] === "18") tileString.shift();
 
         tileString = tileString.toString();
         tileString = tileString.replaceAll(",-1", ",0");  // Remove the -1s because it is unused


### PR DESCRIPTION
Tabletop Simulator supports situations where mecatol rex is not in the center of the galaxy. The mecatol rex tile "18" will appear later in the string, and tts will know not to place mecatol rex in the center. 

However, the export and import of strings where mecatol rex is non-center don't work in the map generator. Instead, you might get extra mecatol rexes when you import the string, or you will be missing the first central system when you export the string.

For example: [Magi's Madness](https://keeganw.github.io/ti4/?settings=T80002862FFF&tiles=85A-2,70,84A-5,0,83A-5,69,0,62,42,90B-1,36,27,34,65,68,46,76,74,75,0,88B-5,26,44,37,66,25,43,48,19,18,78,35,61,79,49,64,45,29,80,50,67,33,0,22,87B-3,86A-5,73,0,38,77,39,40,41,59,0,47,72,24,0,28,91B-1) Click export TTS string, then load the same string again. 

This pr fixes these issues.